### PR TITLE
Mark synchronization closures as non-escaping

### DIFF
--- a/ELFoundation/Utilities/Synchronization.swift
+++ b/ELFoundation/Utilities/Synchronization.swift
@@ -17,7 +17,7 @@ and executes the supplied closure.
 
 Example: synchronized(self) { doSomething() }
 */
-public func synchronized(lock: AnyObject, closure: () -> Void) {
+public func synchronized(lock: AnyObject, @noescape closure: () -> Void) {
     objc_sync_enter(lock)
     closure()
     objc_sync_exit(lock)
@@ -33,7 +33,7 @@ and executes the supplied closure, returning the type T.
 
 Example: let running = synchronized(self) { return true }
 */
-public func synchronized<T>(lock: AnyObject, closure: () -> T) -> T {
+public func synchronized<T>(lock: AnyObject, @noescape closure: () -> T) -> T {
     objc_sync_enter(lock)
     let result: T = closure()
     objc_sync_exit(lock)
@@ -58,7 +58,7 @@ final public class Spinlock {
     - parameter closure: Closure to execute inside of the lock.
     - returns: False if it failed to acquire the lock, otherwise true.
     */
-    public func tryaround(closure: () -> Void) -> Bool {
+    public func tryaround(@noescape closure: () -> Void) -> Bool {
         let held = OSSpinLockTry(&spinlock)
         if !held {
             closure()
@@ -72,7 +72,7 @@ final public class Spinlock {
     
     - parameter closure: Closure to execute inside of the lock.
     */
-    public func around(closure: () -> Void) {
+    public func around(@noescape closure: () -> Void) {
         OSSpinLockLock(&spinlock)
         closure()
         OSSpinLockUnlock(&spinlock)
@@ -84,7 +84,7 @@ final public class Spinlock {
     - parameter closure: Closure to execute inside of the lock.
     - returns: The result of the closure.
     */
-    public func around<T>(closure: () -> T) -> T {
+    public func around<T>(@noescape closure: () -> T) -> T {
         OSSpinLockLock(&spinlock)
         let result: T = closure()
         OSSpinLockUnlock(&spinlock)


### PR DESCRIPTION
#### What does this PR do?

Adds `@noescape` to the closure parameters in the Synchronization utilities.
#### Any background context you want to provide?

This is nice for a few reasons:
- Compiler optimizations.
- No need to use `self.` inside the closures.
- Makes semantics more clear at the call site, since the closures _must_ be non-escaping for these methods to work as expected.
