### PR TITLE
Update Project to ensure all targets build and test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: objective-c
-osx_image: xcode8
+osx_image: xcode8.1
 script:
-   - xcodebuild -project ELFoundation.xcodeproj -scheme ELFoundation -sdk iphonesimulator test -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.0' CODE_SIGNING_REQUIRED=NO
+   - xcodebuild -project ELFoundation.xcodeproj -scheme ELFoundation -sdk iphonesimulator test -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.1' CODE_SIGNING_REQUIRED=NO

--- a/ELFoundation.xcodeproj/project.pbxproj
+++ b/ELFoundation.xcodeproj/project.pbxproj
@@ -576,6 +576,7 @@
 				ONLY_ACTIVE_ARCH = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0.1;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -767,6 +768,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0.1;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -812,6 +814,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0.1;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";

--- a/ELFoundation.xcodeproj/project.pbxproj
+++ b/ELFoundation.xcodeproj/project.pbxproj
@@ -14,8 +14,6 @@
 		17D3490B1D0A24B400D7EBC3 /* NSThreadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17D349061D0A246200D7EBC3 /* NSThreadTests.swift */; };
 		17D3490C1D0A24B700D7EBC3 /* StringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17D349071D0A246200D7EBC3 /* StringTests.swift */; };
 		200045851B4CA4FE005C861B /* NSBundleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 200045841B4CA4FE005C861B /* NSBundleTests.swift */; };
-		C31BAB3D1C7C23710021CEB3 /* NSThreadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C31BAB371C7C23590021CEB3 /* NSThreadTests.swift */; };
-		C31BAB3E1C7C23740021CEB3 /* StringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C31BAB381C7C23590021CEB3 /* StringTests.swift */; };
 		CA072A691C18BDE80059CA99 /* Swizzling.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA072A681C18BDE80059CA99 /* Swizzling.swift */; };
 		CA072A6A1C18BDE80059CA99 /* Swizzling.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA072A681C18BDE80059CA99 /* Swizzling.swift */; };
 		CA39B1BE1C17661800D1A950 /* NSObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA39B1BD1C17661800D1A950 /* NSObject.swift */; };
@@ -89,8 +87,6 @@
 		17D349061D0A246200D7EBC3 /* NSThreadTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSThreadTests.swift; sourceTree = "<group>"; };
 		17D349071D0A246200D7EBC3 /* StringTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringTests.swift; sourceTree = "<group>"; };
 		200045841B4CA4FE005C861B /* NSBundleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSBundleTests.swift; sourceTree = "<group>"; };
-		C31BAB371C7C23590021CEB3 /* NSThreadTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSThreadTests.swift; sourceTree = "<group>"; };
-		C31BAB381C7C23590021CEB3 /* StringTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringTests.swift; sourceTree = "<group>"; };
 		CA072A681C18BDE80059CA99 /* Swizzling.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Swizzling.swift; sourceTree = "<group>"; };
 		CA39B1BD1C17661800D1A950 /* NSObject.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSObject.swift; sourceTree = "<group>"; };
 		CA5C71861AD028D40030B2AC /* Array.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Array.swift; sourceTree = "<group>"; };
@@ -475,11 +471,9 @@
 				CA8CD5731B7A9DE900DA8BF7 /* NSBundleTests.swift in Sources */,
 				CAED574A1CC18D670003E9C9 /* NSURLTests.swift in Sources */,
 				CA8CD5721B7A9DE600DA8BF7 /* ArrayTests.swift in Sources */,
-				C31BAB3D1C7C23710021CEB3 /* NSThreadTests.swift in Sources */,
-				C31BAB3E1C7C23740021CEB3 /* StringTests.swift in Sources */,
-				CA8CD5711B7A9DE300DA8BF7 /* ELFoundationTests.swift in Sources */,
-				17D3490C1D0A24B700D7EBC3 /* StringTests.swift in Sources */,
 				17D3490B1D0A24B400D7EBC3 /* NSThreadTests.swift in Sources */,
+				17D3490C1D0A24B700D7EBC3 /* StringTests.swift in Sources */,
+				CA8CD5711B7A9DE300DA8BF7 /* ELFoundationTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ELFoundation.xcodeproj/xcshareddata/xcschemes/ELFoundation_osx.xcscheme
+++ b/ELFoundation.xcodeproj/xcshareddata/xcschemes/ELFoundation_osx.xcscheme
@@ -20,6 +20,20 @@
                ReferencedContainer = "container:ELFoundation.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CA8CD5621B7A9DCB00DA8BF7"
+               BuildableName = "ELFoundation_osxTests.xctest"
+               BlueprintName = "ELFoundation_osxTests"
+               ReferencedContainer = "container:ELFoundation.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -28,7 +42,26 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CA8CD5621B7A9DCB00DA8BF7"
+               BuildableName = "ELFoundation_osxTests.xctest"
+               BlueprintName = "ELFoundation_osxTests"
+               ReferencedContainer = "container:ELFoundation.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CA8CD5591B7A9DCA00DA8BF7"
+            BuildableName = "ELFoundation.framework"
+            BlueprintName = "ELFoundation_osx"
+            ReferencedContainer = "container:ELFoundation.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>


### PR DESCRIPTION
The commit log should be pretty clear. 

I was first alerted to the possibility of an issue when trying to checkout this module with `carthage` to try to update ELAnalytics which depends on it. 

The output was: 
```
 ✘  ~/dev/ELJSBridge   master ●  carthage update --no-use-binaries
*** Fetching ELLog
*** Fetching ELFoundation
*** Checking out ELFoundation at "v2.0.0"
*** Checking out ELLog at "v3.0.0"
*** xcodebuild output can be found in /var/folders/06/tf7sh6w14wn09ngqwp65lf9h0v9rz6/T/carthage-xcodebuild.PkUlMp.log
*** Building scheme "ELFoundation_osx" in ELFoundation.xcodeproj
** CLEAN FAILED **


The following build commands failed:
        Check dependencies
(1 failure)
** BUILD FAILED **


The following build commands failed:
        Check dependencies
(1 failure)
warning: no umbrella header found for target 'ELFoundation_osx', module map will not be generated
warning: no umbrella header found for target 'ELFoundation_osx', module map will not be generated
A shell task (/usr/bin/xcrun xcodebuild -project /Users/vn00ujn/dev/ELJSBridge/Carthage/Checkouts/ELFoundation/ELFoundation.xcodeproj -scheme ELFoundation_osx -configuration Release ONLY_ACTIVE_ARCH=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY= CARTHAGE=YES clean build) failed with exit code 65:
** CLEAN FAILED **


The following build commands failed:
        Check dependencies
(1 failure)
** BUILD FAILED **


The following build commands failed:
        Check dependencies
(1 failure)
```

There were a small number of changes required.
1) Legacy Swift version was not specified. (As we probably will not go back to swift 2.3, I've set this at the project level to `NO` to track the latest swift version.  (this should fix the above problem)
1) Added The macOS Test target, to the macOS build target. 
![buildtests](https://cloud.githubusercontent.com/assets/573579/21023613/19f4f1ba-bd36-11e6-81f8-b3f19b04423c.png)
And the Tests for macOS Should be configured to run under the macOS Scheme. 
![runtests](https://cloud.githubusercontent.com/assets/573579/21023623/285f8968-bd36-11e6-919f-e187d8e07a31.png)
1) And finally there were files that were not found in the compile step for the macOS Tests target. I re-added them. 
![missingfiles](https://cloud.githubusercontent.com/assets/573579/21023647/43bad942-bd36-11e6-9510-6a9643e858b6.png)
