### PR TITLE
Store isInUnitTest value in-memory

### DIFF
--- a/ELFoundation/TestExtensions/TestHelper.swift
+++ b/ELFoundation/TestExtensions/TestHelper.swift
@@ -13,10 +13,18 @@ import Foundation
  a unit test.
 */
 public func isInUnitTest() -> Bool {
-    if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil {
-        return true
+    struct Holder {
+        
+        /// Stored value after first calculation.
+        static var isInUnitTests: Bool!
     }
-    return false
+    
+    // Make sure stored value isn't nil before function returns
+    if Holder.isInUnitTests == nil {
+        Holder.isInUnitTests = ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
+    }
+    
+    return Holder.isInUnitTests
 }
 
 private enum WaitConditionError: Error {


### PR DESCRIPTION
`isInUnitTest` is inefficient since it accesses current processes environment variables each time it is invoked. It should be safe to store this value in-memory and return without accessing process info again.