### PR TITLE
Add ELFoundation_static target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: objective-c
 osx_image: xcode9.3
 script:
-   - xcodebuild -project ELFoundation.xcodeproj -scheme ELFoundation -sdk iphonesimulator test -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.1' CODE_SIGNING_REQUIRED=NO
+   - xcodebuild -project ELFoundation.xcodeproj -scheme ELFoundation -sdk iphonesimulator clean test -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.1' CODE_SIGNING_REQUIRED=NO
+   - xcodebuild -project ELFoundation.xcodeproj -scheme ELFoundation_static -sdk iphonesimulator clean build -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.1' CODE_SIGNING_REQUIRED=NO

--- a/ELFoundation.xcodeproj/project.pbxproj
+++ b/ELFoundation.xcodeproj/project.pbxproj
@@ -13,6 +13,18 @@
 		17D349091D0A246200D7EBC3 /* NSThreadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17D349061D0A246200D7EBC3 /* NSThreadTests.swift */; };
 		17D3490B1D0A24B400D7EBC3 /* NSThreadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17D349061D0A246200D7EBC3 /* NSThreadTests.swift */; };
 		200045851B4CA4FE005C861B /* NSBundleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 200045841B4CA4FE005C861B /* NSBundleTests.swift */; };
+		3E37BD7120E5604A000B88FF /* NSBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA8804271A962E7000C00CAE /* NSBundle.swift */; };
+		3E37BD7220E5604A000B88FF /* Exceptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA88043F1A96327B00C00CAE /* Exceptions.swift */; };
+		3E37BD7320E5604A000B88FF /* Array.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA5C71861AD028D40030B2AC /* Array.swift */; };
+		3E37BD7420E5604A000B88FF /* DispatchQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17D2293D1DFE4091003FEA78 /* DispatchQueue.swift */; };
+		3E37BD7520E5604A000B88FF /* NSThread.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA9B9EB81AB7660A007E2B04 /* NSThread.swift */; };
+		3E37BD7620E5604A000B88FF /* Synchronization.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA8804421A969F7500C00CAE /* Synchronization.swift */; };
+		3E37BD7720E5604A000B88FF /* ObjectAssociation.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA8CD53A1B7A992C00DA8BF7 /* ObjectAssociation.swift */; };
+		3E37BD7820E5604A000B88FF /* Swizzling.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA072A681C18BDE80059CA99 /* Swizzling.swift */; };
+		3E37BD7920E5604A000B88FF /* NSObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA39B1BD1C17661800D1A950 /* NSObject.swift */; };
+		3E37BD7A20E5604A000B88FF /* TestHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA8CD58F1B7D42DB00DA8BF7 /* TestHelper.swift */; };
+		3E37BD7D20E5604A000B88FF /* ELFoundation.h in Headers */ = {isa = PBXBuildFile; fileRef = CACF2A0F1A9614D20084EFAE /* ELFoundation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3E37BD7F20E5604A000B88FF /* LICENSE in Resources */ = {isa = PBXBuildFile; fileRef = CACF2A2C1A961C120084EFAE /* LICENSE */; };
 		CA072A691C18BDE80059CA99 /* Swizzling.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA072A681C18BDE80059CA99 /* Swizzling.swift */; };
 		CA072A6A1C18BDE80059CA99 /* Swizzling.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA072A681C18BDE80059CA99 /* Swizzling.swift */; };
 		CA39B1BE1C17661800D1A950 /* NSObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA39B1BD1C17661800D1A950 /* NSObject.swift */; };
@@ -78,6 +90,7 @@
 		17D349051D0A246200D7EBC3 /* NSObjectTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSObjectTests.swift; sourceTree = "<group>"; };
 		17D349061D0A246200D7EBC3 /* NSThreadTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSThreadTests.swift; sourceTree = "<group>"; };
 		200045841B4CA4FE005C861B /* NSBundleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSBundleTests.swift; sourceTree = "<group>"; };
+		3E37BD8420E5604A000B88FF /* ELFoundation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ELFoundation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CA072A681C18BDE80059CA99 /* Swizzling.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Swizzling.swift; sourceTree = "<group>"; };
 		CA39B1BD1C17661800D1A950 /* NSObject.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSObject.swift; sourceTree = "<group>"; };
 		CA5C71861AD028D40030B2AC /* Array.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Array.swift; sourceTree = "<group>"; };
@@ -106,6 +119,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		3E37BD7B20E5604A000B88FF /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		CA8CD5561B7A9DCA00DA8BF7 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -209,6 +229,7 @@
 				CACF2A151A9614D20084EFAE /* ELFoundationTests.xctest */,
 				CA8CD55A1B7A9DCA00DA8BF7 /* ELFoundation.framework */,
 				CA8CD5631B7A9DCB00DA8BF7 /* ELFoundation_osxTests.xctest */,
+				3E37BD8420E5604A000B88FF /* ELFoundation.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -257,6 +278,14 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
+		3E37BD7C20E5604A000B88FF /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3E37BD7D20E5604A000B88FF /* ELFoundation.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		CA8CD5571B7A9DCA00DA8BF7 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -276,6 +305,24 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		3E37BD6F20E5604A000B88FF /* ELFoundation_static */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3E37BD8020E5604A000B88FF /* Build configuration list for PBXNativeTarget "ELFoundation_static" */;
+			buildPhases = (
+				3E37BD7020E5604A000B88FF /* Sources */,
+				3E37BD7B20E5604A000B88FF /* Frameworks */,
+				3E37BD7C20E5604A000B88FF /* Headers */,
+				3E37BD7E20E5604A000B88FF /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ELFoundation_static;
+			productName = ELFoundation;
+			productReference = 3E37BD8420E5604A000B88FF /* ELFoundation.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 		CA8CD5591B7A9DCA00DA8BF7 /* ELFoundation_osx */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = CA8CD56B1B7A9DCB00DA8BF7 /* Build configuration list for PBXNativeTarget "ELFoundation_osx" */;
@@ -388,6 +435,7 @@
 			projectRoot = "";
 			targets = (
 				CACF2A091A9614D20084EFAE /* ELFoundation */,
+				3E37BD6F20E5604A000B88FF /* ELFoundation_static */,
 				CACF2A141A9614D20084EFAE /* ELFoundationTests */,
 				CA8CD5591B7A9DCA00DA8BF7 /* ELFoundation_osx */,
 				CA8CD5621B7A9DCB00DA8BF7 /* ELFoundation_osxTests */,
@@ -396,6 +444,14 @@
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		3E37BD7E20E5604A000B88FF /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3E37BD7F20E5604A000B88FF /* LICENSE in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		CA8CD5581B7A9DCA00DA8BF7 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -428,6 +484,23 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		3E37BD7020E5604A000B88FF /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3E37BD7120E5604A000B88FF /* NSBundle.swift in Sources */,
+				3E37BD7220E5604A000B88FF /* Exceptions.swift in Sources */,
+				3E37BD7320E5604A000B88FF /* Array.swift in Sources */,
+				3E37BD7420E5604A000B88FF /* DispatchQueue.swift in Sources */,
+				3E37BD7520E5604A000B88FF /* NSThread.swift in Sources */,
+				3E37BD7620E5604A000B88FF /* Synchronization.swift in Sources */,
+				3E37BD7720E5604A000B88FF /* ObjectAssociation.swift in Sources */,
+				3E37BD7820E5604A000B88FF /* Swizzling.swift in Sources */,
+				3E37BD7920E5604A000B88FF /* NSObject.swift in Sources */,
+				3E37BD7A20E5604A000B88FF /* TestHelper.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		CA8CD5551B7A9DCA00DA8BF7 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -629,6 +702,60 @@
 				SDKROOT = macosx;
 			};
 			name = QADeployment;
+		};
+		3E37BD8120E5604A000B88FF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = ELFoundation/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.walmartlabs.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_NAME = ELFoundation;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
+			};
+			name = Debug;
+		};
+		3E37BD8220E5604A000B88FF /* QADeployment */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = ELFoundation/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.walmartlabs.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_NAME = ELFoundation;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
+			};
+			name = QADeployment;
+		};
+		3E37BD8320E5604A000B88FF /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = ELFoundation/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.walmartlabs.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_NAME = ELFoundation;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
+			};
+			name = Release;
 		};
 		CA8CD56C1B7A9DCB00DA8BF7 /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -886,6 +1013,16 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		3E37BD8020E5604A000B88FF /* Build configuration list for PBXNativeTarget "ELFoundation_static" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3E37BD8120E5604A000B88FF /* Debug */,
+				3E37BD8220E5604A000B88FF /* QADeployment */,
+				3E37BD8320E5604A000B88FF /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		CA8CD56B1B7A9DCB00DA8BF7 /* Build configuration list for PBXNativeTarget "ELFoundation_osx" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/README.md
+++ b/README.md
@@ -21,7 +21,13 @@ github "Electrode-iOS/ELFoundation"
 
 ### Manual
 
-Install by adding `ELFoundation.xcodeproj` to your project and configuring your target to link `ELFoundation.framework`.
+Install by adding `ELFoundation.xcodeproj` to your project and configuring your target to link `ELFoundation.framework` from `ELFoundation` target.
+
+There are two target that builds `ELFoundation.framework`.
+1. `ELFoundation`: Creates dynamicly linked `ELFoundation.framework.`
+2. `ELFoundation_static`: Creates staticly linked `ELFoundation.framework`.
+
+Both targets build the same product (`ELFoundation.framework`), thus linking the same app against both `ELFoundation` and `ELFoundation_static` should be avoided.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ github "Electrode-iOS/ELFoundation"
 Install by adding `ELFoundation.xcodeproj` to your project and configuring your target to link `ELFoundation.framework` from `ELFoundation` target.
 
 There are two target that builds `ELFoundation.framework`.
-1. `ELFoundation`: Creates dynamicly linked `ELFoundation.framework.`
-2. `ELFoundation_static`: Creates staticly linked `ELFoundation.framework`.
+1. `ELFoundation`: Creates dynamically linked `ELFoundation.framework.`
+2. `ELFoundation_static`: Creates statically linked `ELFoundation.framework`.
 
 Both targets build the same product (`ELFoundation.framework`), thus linking the same app against both `ELFoundation` and `ELFoundation_static` should be avoided.
 


### PR DESCRIPTION
This change adds a new target named `ELFoundation_static`. This target builds a static version of `ELFoundation.framework.` 
- It shares the same source files as dynamic ELFoundation framework and builds a product with the same name. 
- Framework's module name is also the same as that of dynamic framework.
- It uses the same Info.plist file as dynamic framework target.
- Travis script is updated to build both targets and clean before building.

Going forward, `ELFoundation_static` framework needs to be managed as well as `ELFoundation` target. Sources added or removed, build setting changes, build phase changes should be reflected on `ELFoundation_static` target.

