### PR TITLE
Updated ELFoundation_osx and ELFoundation_osxTests targets to Swift 5.

### DIFF
--- a/ELFoundation.xcodeproj/project.pbxproj
+++ b/ELFoundation.xcodeproj/project.pbxproj
@@ -686,6 +686,7 @@
 				PRODUCT_NAME = ELFoundation;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
 			};
 			name = QADeployment;
 		};
@@ -700,6 +701,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.walmartlabs.ELFoundation-osxTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
 			};
 			name = QADeployment;
 		};
@@ -775,6 +777,7 @@
 				PRODUCT_NAME = ELFoundation;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -796,6 +799,7 @@
 				PRODUCT_NAME = ELFoundation;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -810,6 +814,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.walmartlabs.ELFoundation-osxTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -824,6 +829,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.walmartlabs.ELFoundation-osxTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
Updates the ELFoundation_osx and ELFoundation_osxTests build targets to use Swift 5.

The currently set Swift 3.0.1 is no longer supported by xcodebuild and will fail builds.